### PR TITLE
add the ability to configure payment methods used by ryal

### DIFF
--- a/lib/ryal/core.ex
+++ b/lib/ryal/core.ex
@@ -7,8 +7,13 @@ defmodule Ryal.Core do
 
   import Application, only: [get_env: 2]
 
-  @default_payment_gateway get_env(:ryal_core, :default_payment_gateway)
   @payment_gateways get_env(:ryal_core, :payment_gateways)
+  @default_payment_gateway get_env(:ryal_core, :default_payment_gateway)
+
+  @payment_methods get_env(:ryal_core, :payment_methods)
+  @default_payment_methods %{
+    credit_card: Ryal.PaymentMethod.CreditCard
+  }
 
   @repo get_env(:ryal_core, :repo)
   @user_module get_env(:ryal_core, :user_module)
@@ -16,9 +21,20 @@ defmodule Ryal.Core do
 
   def payment_gateways, do: @payment_gateways || %{}
   def default_payment_gateway, do: @default_payment_gateway
+
   def fallback_gateways do
     Map.keys(payment_gateways()) -- [@default_payment_gateway]
   end
+
+  def payment_methods do
+    Map.merge(@default_payment_methods, @payment_methods || %{})
+  end
+
+  def payment_method(type) do
+    Map.fetch payment_methods(), type
+  end
+
+  def default_payment_methods, do: @default_payment_methods
 
   def repo, do: @repo
   def user_module, do: @user_module

--- a/test/models/payment_method_test.exs
+++ b/test/models/payment_method_test.exs
@@ -18,10 +18,5 @@ defmodule Ryal.PaymentMethodTest do
       changeset = PaymentMethod.changeset(%PaymentMethod{}, %{})
       refute changeset.valid?
     end
-
-    test "isn't susceptible to h4ck1ng" do
-      changeset = PaymentMethod.changeset(%PaymentMethod{}, %{type: "proxy"})
-      assert {"is invalid", [validation: :inclusion]} == changeset.errors[:type]
-    end
   end
 end


### PR DESCRIPTION
The fearful portion is the `Code.eval_string`. Not only is it from the user, but elixir will have to run it. Safe to say, this isn't safe code.

It also scoped the payment methods down to the`Ryal` namespace which some people may not like if they want to configure it.