### PR TITLE
Payment method data

### DIFF
--- a/lib/ryal/core.ex
+++ b/lib/ryal/core.ex
@@ -7,7 +7,6 @@ defmodule Ryal.Core do
 
   import Application, only: [get_env: 2]
 
-  @payment_gateways get_env(:ryal_core, :payment_gateways)
   @default_payment_gateway get_env(:ryal_core, :default_payment_gateway)
 
   @payment_methods get_env(:ryal_core, :payment_methods)
@@ -19,7 +18,7 @@ defmodule Ryal.Core do
   @user_module get_env(:ryal_core, :user_module)
   @user_table get_env(:ryal_core, :user_table)
 
-  def payment_gateways, do: @payment_gateways || %{}
+  def payment_gateways, do: get_env(:ryal_core, :payment_gateways) || %{}
   def default_payment_gateway, do: @default_payment_gateway
 
   def fallback_gateways do

--- a/lib/ryal/web/models/payment_method.ex
+++ b/lib/ryal/web/models/payment_method.ex
@@ -64,6 +64,8 @@ defmodule Ryal.PaymentMethod do
     |> cast_embed(:proxy, required: true)
   end
 
+  # Loads up the module for the payment method type and then applies it to the
+  # proxy column. This struct carries the module name and the data carried over.
   defp set_module_type(%{type: type} = params) do
     type = String.to_atom type
     proxy_data = Map.get(params, :proxy, %{})

--- a/lib/ryal/web/models/payment_method.ex
+++ b/lib/ryal/web/models/payment_method.ex
@@ -14,6 +14,7 @@ defmodule Ryal.PaymentMethod do
 
       iex> Ryal.PaymentMethod.changeset(%Ryal.PaymentMethod{}, %{
         type: "credit_card",
+        user_id: 1,
         proxy: %{
           name: "Bobby Orr",
           number: "4242 4242 4242 4242",

--- a/lib/ryal/web/models/payment_method.ex
+++ b/lib/ryal/web/models/payment_method.ex
@@ -14,7 +14,7 @@ defmodule Ryal.PaymentMethod do
 
       iex> Ryal.PaymentMethod.changeset(%Ryal.PaymentMethod{}, %{
         type: "credit_card",
-        data: %{
+        proxy: %{
           name: "Bobby Orr",
           number: "4242 4242 4242 4242",
           month: "03",

--- a/lib/ryal/web/models/payment_methods/credit_card.ex
+++ b/lib/ryal/web/models/payment_methods/credit_card.ex
@@ -21,12 +21,12 @@ defmodule Ryal.PaymentMethod.CreditCard do
     field :name, :string
 
     field :last_digits, :string
-    field :number, :string, virtual: true
+    field :number, :string
 
     field :month, :string
     field :year, :string
 
-    field :cvc, :string, virtual: true
+    field :cvc, :string
   end
 
   @required_fields ~w(name number month year cvc)a

--- a/lib/ryal/web/models/payment_methods/credit_card.ex
+++ b/lib/ryal/web/models/payment_methods/credit_card.ex
@@ -15,7 +15,9 @@ defmodule Ryal.PaymentMethod.CreditCard do
 
   use Ecto.Schema
 
-  import Ecto.Changeset, only: [cast: 3, validate_required: 2, put_change: 3]
+  import Ecto.Changeset, only: [
+    cast: 3, validate_required: 2, put_change: 3, delete_change: 2
+  ]
 
   embedded_schema do
     field :name, :string
@@ -40,18 +42,26 @@ defmodule Ryal.PaymentMethod.CreditCard do
     struct
     |> cast(params, @required_fields)
     |> validate_required(@required_fields)
+    |> format_number
     |> cast_number_to_last_digits
     |> validate_required([:last_digits])
+    |> delete_change(:number)
+    |> delete_change(:cvc)
+  end
+
+  def format_number(changeset) do
+    if Map.has_key?(changeset.changes, :number) do
+      number = Regex.replace(~r/[[:space:]]/, changeset.changes.number, "")
+      put_change(changeset, :number, number)
+    else
+      changeset
+    end
   end
 
   defp cast_number_to_last_digits(changeset) do
     if Map.has_key?(changeset.changes, :number) do
-      number = Regex.replace(~r/[[:space:]]/, changeset.changes.number, "")
-      {_, digits} = String.split_at(number, -4)
-
-      changeset
-      |> put_change(:number, number)
-      |> put_change(:last_digits, digits)
+      {_, digits} = String.split_at(changeset.changes.number, -4)
+      put_change(changeset, :last_digits, digits)
     else
       changeset
     end

--- a/lib/ryal/web/models/payment_methods/proxy.ex
+++ b/lib/ryal/web/models/payment_methods/proxy.ex
@@ -43,8 +43,12 @@ defmodule Ryal.PaymentMethod.Proxy do
       |> struct(%{})
       |> module.changeset(params)
 
+    data = proxy_changeset
+      |> Ecto.Changeset.apply_changes
+      |> Map.from_struct
+
     %__MODULE__{}
-    |> cast(%{data: params}, [:data])
+    |> cast(%{data: data}, [:data])
     |> Map.merge(%{
       errors: proxy_changeset.errors,
       valid?: proxy_changeset.valid?

--- a/test/models/payment_methods/credit_card_test.exs
+++ b/test/models/payment_methods/credit_card_test.exs
@@ -23,17 +23,19 @@ defmodule Ryal.PaymentMethod.CreditCardTest do
     test "will create a new credit card changeset", %{attrs: params} do
       changeset = CreditCard.changeset(%CreditCard{}, params)
 
-      assert changeset.changes.number == "4242424242424242"
+      assert Map.fetch(changeset.changes, :number) == :error
+      assert Map.fetch(changeset.changes, :cvc) == :error
       assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end
 
     test "can use numbers with tabs", %{attrs: params} do
       params = %{params | number: "4242 4242  4242  4242"}
-      changeset = CreditCard.changeset(%CreditCard{}, params)
+      changeset = %CreditCard{}
+        |> Ecto.Changeset.cast(params, Map.keys(params))
+        |> CreditCard.format_number
 
       assert changeset.changes.number == "4242424242424242"
-      assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end
 
@@ -45,10 +47,12 @@ defmodule Ryal.PaymentMethod.CreditCardTest do
         4242
         """
       }
-      changeset = CreditCard.changeset(%CreditCard{}, params)
+
+      changeset = %CreditCard{}
+        |> Ecto.Changeset.cast(params, Map.keys(params))
+        |> CreditCard.format_number
 
       assert changeset.changes.number == "4242424242424242"
-      assert changeset.changes.last_digits == "4242"
       assert changeset.valid?
     end
   end


### PR DESCRIPTION
This is my last go at trying to fixup how we store data for the Ryal Payment Methods. Here's the before and after of what we store when we persist the payment method in the proxy column:

Before:

```json
{
  "id": "627caf97-92f8-490a-b45d-e994f0bfb0ee",
  "data": {
    "id": null,
    "cvc": "123",
    "name": "Bobby Orr",
    "year": "2019",
    "month": "08",
    "number": "4242 4242 4242 4242",
    "last_digits": null
  }
}
```

After:

```json
{
  "id": "ae7c3bd5-273b-4ffe-b7ce-6a46a9396a65",
  "data": {
    "id": null,
    "cvc": null,
    "name": "Bobby Orr",
    "year": "2048",
    "month": "03",
    "number": null,
    "last_digits": "4242"
  }
}
```